### PR TITLE
Refactor OpenAI client initialization to runtime

### DIFF
--- a/src/app/api/generate-caption/route.ts
+++ b/src/app/api/generate-caption/route.ts
@@ -2,7 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
-import { openai } from '@/services/openai';
+import { getOpenAIClient } from '@/services/openai';
 import {
   ValidationError,
   validateCaptionInput,
@@ -113,7 +113,7 @@ export async function POST(req: NextRequest) {
 
     prompt += '\nMake it authentic, engaging, and suitable for Instagram. Include relevant hashtags.';
 
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAIClient().chat.completions.create({
       model: DEFAULT_MODEL,
       messages: [
         {

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -1,7 +1,17 @@
-// src/lib/openai.ts
-
 import { OpenAI } from 'openai';
 
-export const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+let openaiClient: OpenAI | null = null;
+
+export function getOpenAIClient(): OpenAI {
+  const apiKey = process.env.OPENAI_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is missing');
+  }
+
+  if (!openaiClient) {
+    openaiClient = new OpenAI({ apiKey });
+  }
+
+  return openaiClient;
+}


### PR DESCRIPTION
### Motivation
- Prevent build-time failures caused by creating an OpenAI client at module import when `OPENAI_API_KEY` is not set, and surface a clear runtime error instead.

### Description
- Replace eager module-level `new OpenAI(...)` with a lazy factory `getOpenAIClient()` in `src/services/openai.ts`. 
- Update the caption generation API to call `getOpenAIClient()` at request time (`src/app/api/generate-caption/route.ts`).
- Add explicit error handling when `OPENAI_API_KEY` is missing so the application fails at runtime with a clear message instead of during build.

### Testing
- Ran `npm run lint` and it passed without errors. ✅
- Ran `npx tsc --noEmit` and TypeScript checks passed. ✅
- Attempted `npm run build`; the OpenAI import-time failure is resolved, but the build now fails during prerender due to missing Supabase environment variables required by `@supabase/ssr`. ⚠️
- No test files were found in the repository, so no unit/test-file-specific runs were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa71a88b6c83208b9da175c066e4e6)