### PR TITLE
Refactor OpenAI client initialization and update docs/project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,78 @@
 # Caption Genius
 
-Caption Genius helps creators and teams generate better social media captions faster.
+Caption Genius is a Next.js app for generating social-media captions with configurable tone and style preferences.
 
-It turns your idea, topic, or content focus into polished caption options tailored for your audience and voice, so you can spend less time writing and more time publishing.
+## Tech Stack
+- Next.js (App Router) + React + TypeScript
+- Supabase (auth + data)
+- OpenAI API (caption generation)
+- Tailwind CSS
+
+## Quick Start
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create an environment file (`.env.local`) with the required values:
+   ```env
+   OPENAI_API_KEY=...
+   OPENAI_MODEL=gpt-4o-mini
+   DAILY_CAPTION_LIMIT=30
+
+   NEXT_PUBLIC_SUPABASE_URL=...
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+   SUPABASE_SERVICE_ROLE_KEY=...
+   ```
+3. Start development:
+   ```bash
+   npm run dev
+   ```
+
+## Scripts
+- `npm run dev` — start local dev server
+- `npm run build` — production build
+- `npm run start` — run production server
+- `npm run lint` — run ESLint on `src`
+
+## Project Structure
+The codebase is organized by runtime boundary first (`app`, `components`, `lib`, `services`), then by domain.
+
+```text
+src/
+├─ app/                    # Routes, layouts, providers, API handlers
+│  ├─ api/
+│  │  ├─ auth/             # Auth route handlers
+│  │  └─ generate-caption/ # Caption generation endpoint
+│  └─ */page.tsx           # Route pages (dashboard, caption, etc.)
+├─ components/
+│  ├─ ui/                  # Shared primitive components
+│  ├─ layout/              # Header/Footer and layout-level UI
+│  └─ dashboard/           # Dashboard-specific components
+├─ data/                   # Static app data/config used by views
+├─ features/               # Feature-scoped hooks/helpers
+├─ lib/
+│  ├─ supabase/            # Supabase client/server helpers
+│  ├─ validation/          # Input/data validation logic
+│  └─ utils/               # Generic utility helpers
+├─ services/               # External service wrappers (OpenAI)
+└─ types/                  # Shared TypeScript declarations
+```
+
+## Navigation & Maintainability Guidelines
+To keep this repository easy to navigate:
+
+- **Route code stays in `src/app`**: keep page-level orchestration in route files and move reusable logic outward.
+- **UI primitives in `components/ui` only**: domain-specific UI should live in a feature folder (`dashboard`, etc.).
+- **Server/client integrations isolated**: Supabase helpers in `lib/supabase`; third-party API wrappers in `services`.
+- **Validation close to shared libs**: schema/guard logic belongs in `lib/validation` so APIs and pages can reuse it.
+- **Feature hooks under `features/<feature>/hooks`**: keeps hook ownership obvious.
+
+## Recommended Placement for New Code
+- New route/API: `src/app/...`
+- New reusable component: `src/components/ui/...`
+- New feature-specific component: `src/components/<feature>/...`
+- New service integration: `src/services/...`
+- New shared utility/type: `src/lib/...` or `src/types/...`
+
+## Current Test Status
+There are currently no dedicated test files (`*.test.*` / `*.spec.*`) in this repository. If tests are added, prefer colocating them near the feature they validate.

--- a/fileStructure.txt
+++ b/fileStructure.txt
@@ -1,13 +1,29 @@
 /src
-├── /app           # App Router pages, layouts, API routes, providers
-├── /components    # Reusable UI and layout components
-├── /config        # App-level config values
-├── /context       # React context providers
-├── /data          # Static/data config used by views
-├── /features      # Feature-specific hooks and config
-├── /lib           # Shared library code (auth, utils, supabase, validation)
-├── /services      # Service integrations (OpenAI, etc.)
-├── /styles        # Global styling
-├── /types         # Shared TypeScript types
-└── /utils         # General helper functions
-
+├── /app                        # App Router routes, layouts, providers, API handlers
+│   ├── /api
+│   │   ├── /auth               # auth callback, password, account routes
+│   │   └── /generate-caption   # caption generation endpoint
+│   ├── /providers              # top-level app providers
+│   ├── /account
+│   ├── /analytics
+│   ├── /calendar
+│   ├── /caption
+│   ├── /customize
+│   ├── /dashboard
+│   ├── /history
+│   ├── /login
+│   └── /signup
+├── /components
+│   ├── /dashboard              # dashboard-only components
+│   ├── /layout                 # header/footer/layout components
+│   └── /ui                     # reusable shared UI primitives
+├── /data                       # static data and config consumed by pages/components
+├── /features
+│   └── /caption
+│       └── /hooks              # caption feature hooks
+├── /lib
+│   ├── /supabase               # server/client supabase helpers + actions
+│   ├── /utils                  # utility helpers
+│   └── /validation             # input and payload validation
+├── /services                   # external integrations (OpenAI)
+└── /types                      # global/shared TS types

--- a/src/app/api/generate-caption/route.ts
+++ b/src/app/api/generate-caption/route.ts
@@ -2,7 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
-import { openai } from '@/services/openai';
+import { getOpenAIClient } from '@/services/openai';
 import {
   ValidationError,
   validateCaptionInput,
@@ -113,7 +113,7 @@ export async function POST(req: NextRequest) {
 
     prompt += '\nMake it authentic, engaging, and suitable for Instagram. Include relevant hashtags.';
 
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAIClient().chat.completions.create({
       model: DEFAULT_MODEL,
       messages: [
         {

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -1,7 +1,17 @@
-// src/lib/openai.ts
-
 import { OpenAI } from 'openai';
 
-export const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+let openaiClient: OpenAI | null = null;
+
+export function getOpenAIClient(): OpenAI {
+  const apiKey = process.env.OPENAI_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is missing');
+  }
+
+  if (!openaiClient) {
+    openaiClient = new OpenAI({ apiKey });
+  }
+
+  return openaiClient;
+}


### PR DESCRIPTION
### Motivation
- Centralize OpenAI client creation and surface a clear error when `OPENAI_API_KEY` is missing. 
- Improve onboarding and maintenance by providing a clearer project README and file structure. 
- Update the caption-generation route to use the new client factory for consistency and testability.

### Description
- Replace the previously exported `openai` instance with a lazy-initializing factory `getOpenAIClient()` in `src/services/openai.ts` that throws if `OPENAI_API_KEY` is not set. 
- Update `src/app/api/generate-caption/route.ts` to import and use `getOpenAIClient()` instead of the old `openai` export when creating chat completions. 
- Overhaul `README.md` to include the tech stack, quick-start instructions, scripts, project structure, navigation/maintainability guidelines, and a note about current test status. 
- Update `fileStructure.txt` to reflect a more detailed `src` layout including API routes, feature folders, and component organization.

### Testing
- There are currently no dedicated automated tests (`*.test.*` / `*.spec.*`) in the repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa71a88b6c83208b9da175c066e4e6)